### PR TITLE
Set cursor to start instead of empty range on clearHighlight

### DIFF
--- a/google/grammarcheck.ts
+++ b/google/grammarcheck.ts
@@ -268,7 +268,7 @@ function clearHighlight() {
     const selection = doc.getSelection();
     if (selection) {
         for (let element of selection.getRangeElements()) {
-            const pos = doc.newPosition(element.getElement(), element.getStartOffset());
+            const pos = doc.newPosition(element.getElement(), element.getEndOffsetInclusive() + 1);
             doc.setCursor(pos);
             return;
         }

--- a/google/grammarcheck.ts
+++ b/google/grammarcheck.ts
@@ -265,8 +265,14 @@ function highlightError(errorText: string, errorIndex: number, paragraphIndex: n
 
 function clearHighlight() {
     const doc = DocumentApp.getActiveDocument()
-    const range = doc.newRange()
-    doc.setSelection(range.build())
+    const selection = doc.getSelection();
+    if (selection) {
+        for (let element of selection.getRangeElements()) {
+            const pos = doc.newPosition(element.getElement(), element.getStartOffset());
+            doc.setCursor(pos);
+            return;
+        }
+    }
 }
 
 function changeLanguage(key: string) {


### PR DESCRIPTION
The highlight/selection seems to not get cleared by setting it to a new range. This change does `setCursor` instead with position at start of selection, which seems to clear the selection. 

(original version set it to start of doc, but that leads to scrolling if error is at e.g. page 2)
